### PR TITLE
include just one error line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+.idea
+yarn.lock

--- a/index.js
+++ b/index.js
@@ -134,15 +134,11 @@ function tapPretty(argv, inputStream) {
             this.push(diagIndent(underline(red(`Expected ${expected}, but got ${actual}\n`))));
           }
         } else if (obj.value.operator === 'error' && 'stack' in obj.value) {
-          const diagIndent = (s) => `      ${s}`;
           // Prettier error message
-          // console.log('obj', obj.value.stack)
-          const fileLines = obj.value.stack.match(/\(file:\/\/.+\)/g) || [];
-          if (fileLines[0]) {
-            this.push(diagIndent(`at ${fileLines[0]}`));
-          }
-          // console.log('fileLines', fileLines)
-          // console.log('__dirname', __dirname)
+          const diagIndent = (s) => `      ${s}`;
+          const errorLines = obj.value.stack.split('\n').slice(1);
+          const indentedErrorLines = errorLines.map((l) => diagIndent(l)).join('\n');
+          this.push(gray(indentedErrorLines));
         }
         break;
       }

--- a/index.js
+++ b/index.js
@@ -160,6 +160,10 @@ function tapPretty(argv, inputStream) {
     const time = new Date().getTime() - startTime;
 
     writer.write({ type: 'summary', numAsserts, numPassed: countedPasses, numErrors, time });
+
+    if (numErrors > 0) {
+      process.exit(1);
+    }
   });
 
   return inputStream.pipe(tap).pipe(writer);

--- a/index.js
+++ b/index.js
@@ -133,6 +133,16 @@ function tapPretty(argv, inputStream) {
           } else {
             this.push(diagIndent(underline(red(`Expected ${expected}, but got ${actual}\n`))));
           }
+        } else if (obj.value.operator === 'error' && 'stack' in obj.value) {
+          const diagIndent = (s) => `      ${s}`;
+          // Prettier error message
+          // console.log('obj', obj.value.stack)
+          const fileLines = obj.value.stack.match(/\(file:\/\/.+\)/g) || [];
+          if (fileLines[0]) {
+            this.push(diagIndent(`at ${fileLines[0]}`));
+          }
+          // console.log('fileLines', fileLines)
+          // console.log('__dirname', __dirname)
         }
         break;
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tap-pretty",
-  "version": "0.0.5",
+  "version": "0.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tap-pretty",
-      "version": "0.0.5",
+      "version": "0.0.8",
       "license": "MIT",
       "dependencies": {
         "colorette": "2.0.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "tap-pretty",
-  "version": "0.0.6",
+  "name": "tap-pretty-with-errors",
+  "version": "0.0.7",
   "description": "Yet another TAP output formatter",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tap-pretty-with-errors",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Yet another TAP output formatter",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hi,

I really like your tap output formatting but I thought it would be very beneficial if at least just one error line was included in the output to help navigate to where the error occurred.

Here is what the output now looks like with my changes.


<img width="483" alt="image" src="https://github.com/alexscheelmeyer/tap-pretty/assets/14286600/f31e7171-e3e7-4104-b407-e3c5720fb3be">

